### PR TITLE
Can set render process low priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ PapyrusTasks       String [Array]     An array of additional arguments for papyr
                                       PapyrusCS process after the previous one has
                                       finished (e.g. for rendering of multiple
                                       dimensions)
+
+LowPriority        Boolean            Start render process at lowest OS priority
+                                      (Default: false)
 -------------------
 ADDITIONAL SETTINGS
 -------------------

--- a/src/Automation/RenderManager.cs
+++ b/src/Automation/RenderManager.cs
@@ -60,8 +60,23 @@ namespace Vellum.Automation
                 _renderer.StartInfo.RedirectStandardInput = true;
 
                 Log(String.Format("{0}{1}Rendering map {2}/{3}...", _tag, _indent, i + 1, RunConfig.Renders.PapyrusTasks.Length));
+                
+                // To pre-emptively start a process with defined priority you need to set calling process to said priority.
+                Process parentProcess = Process.GetCurrentProcess();
+                ProcessPriorityClass parentPriority = parentProcess.PriorityClass;
+                if(RunConfig.Renders.LowPriority)
+                {
+                    parentProcess.PriorityClass = ProcessPriorityClass.Idle;
+                }
 
                 _renderer.Start();
+
+                if(RunConfig.Renders.LowPriority)
+                {
+                    // Set back parent process to original priority
+                    parentProcess.PriorityClass = parentPriority;
+                }
+                
                 _renderer.WaitForExit();
             }
 

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -384,7 +384,8 @@ namespace Vellum
                                 "--dim 1",
                                 "--dim 2"
                             },
-                            PapyrusOutputPath = ""
+                            PapyrusOutputPath = "",
+                            LowPriority = false
                         },
                         QuietMode = false,
                         HideStdout = true,

--- a/src/RunConfiguration.cs
+++ b/src/RunConfiguration.cs
@@ -35,6 +35,6 @@
         public double RenderInterval;
         public string PapyrusGlobalArgs;
         public string[] PapyrusTasks;
-
+        public bool LowPriority;
     }
 }


### PR DESCRIPTION
Pre-emptive priority set trick(see comment in code) does not affect BDS process priority at any moment.