### PR TITLE
trim newline on level name import (windows errors)

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -63,7 +63,7 @@ namespace Vellum
                 Console.Write($"Reading \"{_serverPropertiesFileName}\"... ");
 
                 using (StreamReader reader = new StreamReader(File.OpenRead(Path.Join(bdsDirPath, _serverPropertiesFileName))))
-                    worldName = Regex.Match(reader.ReadToEnd(), @"^level\-name\=(.+)", RegexOptions.Multiline).Groups[1].Value;
+                    worldName = Regex.Match(reader.ReadToEnd(), @"^level\-name\=(.+)", RegexOptions.Multiline).Groups[1].Value.Trim();
 
                 Console.WriteLine("Done!");
 


### PR DESCRIPTION
Crash on windows since it tries to find a file with a newline at the end