### PR TITLE
fix user reported gap in backup coverage

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -195,10 +195,10 @@ namespace Vellum
                     {
                         if (nextBackup)
                         {
-                            InvokeBackup(worldPath, tempWorldPath);
-
                             if (RunConfig.Backups.OnActivityOnly && playerCount == 0)
                                 nextBackup = false;
+                            InvokeBackup(worldPath, tempWorldPath);
+
                         } else
                             Console.WriteLine("Skipping this backup because no players were online since the last one was taken...");
                     };


### PR DESCRIPTION
Switch two lines to eliminate a small gap in backup coverage reported by user (changes made by a player during backup who logs off before backup is done would not have their work backed up until another player logs in)