### PR TITLE
methods to tell watchdog to chill and to start working again

### DIFF
--- a/src/Automation/Watchdog.cs
+++ b/src/Automation/Watchdog.cs
@@ -8,6 +8,7 @@ namespace Vellum.Automation
     {
         public uint RetryLimit = 3;
         private uint _failRetryCount = 0;
+        private bool ignoreShutdown = false;
 
         #region PLUGIN
         public Version Version { get; }
@@ -25,7 +26,7 @@ namespace Vellum.Automation
             processManager.Process.EnableRaisingEvents = true;
             processManager.Process.Exited += (object sender, EventArgs e) =>
             {
-                if (processManager.Process.ExitCode != 0)
+                if (processManager.Process.ExitCode != 0 && !ignoreShutdown)
                 {
                     CallHook((byte)Hook.CRASH, new HookEventArgs() { Attachment = processManager.Process.ExitCode });
 
@@ -52,6 +53,16 @@ namespace Vellum.Automation
                 CallHook((byte)Hook.STABLE, new HookEventArgs() { Attachment = _failRetryCount });
                 _failRetryCount = 0;
             });
+        }
+
+        public void Disable()
+        {
+            ignoreShutdown = true;
+        }
+
+        public void Enable()
+        {
+            ignoreShutdown = false;
         }
     }
 }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -423,6 +423,7 @@ namespace Vellum
                                     shutdownTimer.Elapsed += (object sender, ElapsedEventArgs e) =>
                                     {
                                         // _renderManager.Abort();
+                                        _bdsWatchdog.Disable();
                                         bds.SendInput("stop");
                                         bds.Process.WaitForExit();
                                         bds.Close();


### PR DESCRIPTION
Watchdog still bringing the server back up in current build. This PR adds methods to the watchdog class to tell it not to act, and to tell it to start watching again (for the autorestart plugin to be able to turn it back on again)