### PR TITLE
addition of multi-render app support and log output adjustments

### DIFF
--- a/src/Automation/BackupManager.cs
+++ b/src/Automation/BackupManager.cs
@@ -15,6 +15,8 @@ namespace Vellum.Automation
         public RunConfiguration RunConfig;
         ///<summary>Time in milliseconds to wait until sending next <code>save query</code> command to <code>ProcessManager</code>'s process</summary>
         public int QueryTimeout { get; set; } = 500;
+		private string _tag = "[    VELLUM:BACKUP       ] ";
+
 
         #region PLUGIN
         public Version Version { get; }
@@ -48,7 +50,7 @@ namespace Vellum.Automation
         public void CreateWorldBackup(string worldPath, string destinationPath, bool fullCopy, bool archive)
         {
             Processing = true;
-
+			Log(String.Format("{0}Creating initial temporary copy of world directory...", _tag));
             CallHook((byte)Hook.BEGIN);
 
             #region PRE EXEC

--- a/src/Automation/RenderManager.cs
+++ b/src/Automation/RenderManager.cs
@@ -11,6 +11,7 @@ namespace Vellum.Automation
         private ProcessManager _bds;
         private Process _renderer;
         public RunConfiguration RunConfig;
+		private string _tag = "[    VELLUM:RENDER       ] ";
 
         #region PLUGIN
         public Version Version { get; }
@@ -28,8 +29,9 @@ namespace Vellum.Automation
             _bds = p;
             RunConfig = runConfig;
         }
-
-        public void Start(string worldPath)
+		
+		
+        public void Start(string worldPath, string keyFilter = "(.)")
         {
             Processing = true;
 
@@ -45,57 +47,71 @@ namespace Vellum.Automation
             string tempPathCopy = worldPath.Replace(Path.GetFileName(worldPath), prfx + Path.GetFileName(worldPath));
             BackupManager.CopyDirectory(worldPath, tempPathCopy);
 
-            // Prepare map render output directory
-            if (!Directory.Exists(RunConfig.Renders.PapyrusOutputPath))
-            {
-                Directory.CreateDirectory(RunConfig.Renders.PapyrusOutputPath);
-            }
 
-            for (int i = 0; i < RunConfig.Renders.PapyrusTasks.Length; i++)
-            {
-                Dictionary<string, string> placeholderReplacements = new Dictionary<string, string>()
-                {
-                    { "$WORLD_PATH", String.Format("\"{0}\"", tempPathCopy) },
-                    { "$OUTPUT_PATH", String.Format("\"{0}\"", RunConfig.Renders.PapyrusOutputPath) },
-                    { "${WORLD_PATH}", String.Format("\"{0}\"", tempPathCopy) },
-                    { "${OUTPUT_PATH}", String.Format("\"{0}\"", RunConfig.Renders.PapyrusOutputPath) }
-                };
+			// Allow multiple external applications that use the same temporary copy in sequence and iterate through them, skipping over disabled engines.
+			RenderConfig RenderApp;
+			foreach(KeyValuePair<string, RenderConfig> renderEntry in RunConfig.Renders)
+			{
+				RenderApp = renderEntry.Value;
+				
+				// Global render settings won't be executed, non-existing apps and disabled items will be skipped, and optionally only filtered and active items will run.
+				if (renderEntry.Key != "Global" && System.Text.RegularExpressions.Regex.IsMatch(renderEntry.Key,keyFilter) && File.Exists(RenderApp.RenderAppBinPath) && RenderApp.EnableRenders )
+				{
+					
+					// Prepare map render output directory
+					if (!Directory.Exists(RenderApp.RenderAppOutputPath))
+					{
+						Directory.CreateDirectory(RenderApp.RenderAppOutputPath);
+					}
+					
+					// Go through this renders task list
+					for (int i = 0; i < RenderApp.RenderAppTasks.Length; i++)
+					{
+						Dictionary<string, string> placeholderReplacements = new Dictionary<string, string>()
+						{
+							{ "$WORLD_PATH", String.Format("\"{0}\"", tempPathCopy) },
+							{ "$OUTPUT_PATH", String.Format("\"{0}\"", RenderApp.RenderAppOutputPath) },
+							{ "${WORLD_PATH}", String.Format("\"{0}\"", tempPathCopy) },
+							{ "${OUTPUT_PATH}", String.Format("\"{0}\"", RenderApp.RenderAppOutputPath) }
+						};
 
-                string args = RunConfig.Renders.PapyrusGlobalArgs;
+						string args = RenderApp.RenderAppGlobalArgs;
 
-                foreach (KeyValuePair<string, string> kv in placeholderReplacements)
-                    args = args.Replace(kv.Key, kv.Value);
+						foreach (KeyValuePair<string, string> kv in placeholderReplacements)
+							args = args.Replace(kv.Key, kv.Value);
+					
+						_renderer = new Process();
+						_renderer.StartInfo.FileName = RenderApp.RenderAppBinPath;
+						_renderer.StartInfo.WorkingDirectory = Path.GetDirectoryName(RenderApp.RenderAppBinPath);
+						_renderer.StartInfo.Arguments = $"{args} {RenderApp.RenderAppTasks[i]}";
+						_renderer.StartInfo.RedirectStandardOutput = RunConfig.HideStdout;
+						_renderer.StartInfo.RedirectStandardInput = true;
 
-                _renderer = new Process();
-                _renderer.StartInfo.FileName = RunConfig.Renders.PapyrusBinPath;
-                _renderer.StartInfo.WorkingDirectory = Path.GetDirectoryName(RunConfig.Renders.PapyrusBinPath);
-                _renderer.StartInfo.Arguments = $"{args} {RunConfig.Renders.PapyrusTasks[i]}";
-                _renderer.StartInfo.RedirectStandardOutput = RunConfig.HideStdout;
-                _renderer.StartInfo.RedirectStandardInput = true;
+						Log(String.Format("{0}{1}Rendering map {2}/{3}...", _tag, _indent, i + 1, RenderApp.RenderAppTasks.Length));
+						
+						// To pre-emptively start a process with defined priority you need to set calling process to said priority.
+						Process parentProcess = Process.GetCurrentProcess();
+						ProcessPriorityClass parentPriority = parentProcess.PriorityClass;
+						if(RenderApp.LowPriority)
+						{
+							parentProcess.PriorityClass = ProcessPriorityClass.Idle;
+						}
 
-                Log(String.Format("{0}{1}Rendering map {2}/{3}...", _tag, _indent, i + 1, RunConfig.Renders.PapyrusTasks.Length));
-                
-                // To pre-emptively start a process with defined priority you need to set calling process to said priority.
-                Process parentProcess = Process.GetCurrentProcess();
-                ProcessPriorityClass parentPriority = parentProcess.PriorityClass;
-                if(RunConfig.Renders.LowPriority)
-                {
-                    parentProcess.PriorityClass = ProcessPriorityClass.Idle;
-                }
+						_renderer.Start();
+						// TODO: needs a try /catch block to handle sub-process failure events (e.g. cleanup/recover) without killing the BDS server, since they don't interact
+						CallHook((byte)Hook.NEXT, new HookEventArgs() { Attachment = i });
 
-                _renderer.Start();
-
-                CallHook((byte)Hook.NEXT, new HookEventArgs() { Attachment = i });
-
-                if(RunConfig.Renders.LowPriority)
-                {
-                    // Set back parent process to original priority
-                    parentProcess.PriorityClass = parentPriority;
-                }
-                
-                _renderer.WaitForExit();
-            }
-
+						if(RenderApp.LowPriority)
+						{
+							// Set back parent process to original priority
+							parentProcess.PriorityClass = parentPriority;
+						}
+						
+						_renderer.WaitForExit();
+					}
+				}
+			}
+			
             Log(String.Format("{0}{1}Cleaning up...", _tag, _indent));
 
             Directory.Delete(tempPathCopy, true);

--- a/src/RunConfiguration.cs
+++ b/src/RunConfiguration.cs
@@ -4,7 +4,7 @@
     {
         public string BdsBinPath;
         public BackupConfig Backups;
-        public RenderConfig Renders;
+        public System.Collections.Generic.Dictionary<string, RenderConfig> Renders;
         public bool QuietMode;
         public bool HideStdout;
         public bool BusyCommands;
@@ -32,11 +32,11 @@
     public class RenderConfig
     {
         public bool EnableRenders;
-        public string PapyrusBinPath;
-        public string PapyrusOutputPath;
+        public string RenderAppBinPath;
+        public string RenderAppOutputPath;
         public double RenderInterval;
-        public string PapyrusGlobalArgs;
-        public string[] PapyrusTasks;
+        public string RenderAppGlobalArgs;
+        public string[] RenderAppTasks;
         public bool LowPriority;
     }
 


### PR DESCRIPTION
_(not sure what's gone wrong with the spacing. I may withdraw and resubmit if it's an issue)_

The configuration and rendering has been updated to allow for an arbitrary selection of multiple render tools, with independent render control.
There's some small pre-work done to allow selective triggering of render apps via the console, but that part hasn't been implemented yet.
There are also some console output changes to better distinguish which component is doing the reporting.
**This is a breaking change to the config file format, which now looks like this (first version, without rationalisation of properties):**
```
 "Renders": {
    "Global": {
      "EnableRenders": true,
      "RenderAppBinPath": "",
      "RenderAppOutputPath": "",
      "RenderInterval": 240.0,
      "RenderAppGlobalArgs": "",
      "RenderAppTasks": [],
      "LowPriority": false
    },
    "bedrock-viz": {
      "EnableRenders": true,
      "RenderAppBinPath": "C:\\Minecraft\\Tools\\bedrock-viz.1.7\\bedrock-viz.exe",
      "RenderAppOutputPath": "test\\bedrock-viz",
      "RenderInterval": 240.0,
      "RenderAppGlobalArgs": " --shortrun --no-force-geojson --detail --db $WORLD_PATH --outdir $OUTPUT_PATH ",
      "RenderAppTasks": [
        "--html-most --slices --all-image"
      ],
      "LowPriority": false
    },
    "papyruscs": {
      "EnableRenders": true,
      "RenderAppBinPath": "C:\\Minecraft\\Tools\\papyruscs\\PapyrusCs.exe",
      "RenderAppOutputPath": "test\\papyruscs",
      "RenderInterval": 240.0,
      "RenderAppGlobalArgs": "-w $WORLD_PATH -o $OUTPUT_PATH --htmlfile index.html -f webp -q -1 --rendermode Heightmap",
      "RenderAppTasks": [
        "--dim 0",
        "--dim 1",
        "--dim 2",
        "--dim 0 -p underground",
        "--dim 0 -p aquatic"
      ],
      "LowPriority": false
    }
```